### PR TITLE
Update scikit-learn to 1.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "pandas==1.4.4",
         "python-dateutil==2.8.2",
         "pyyaml==6.0",
-        "scikit-learn==1.1.3",
+        "scikit-learn==1.5.0",
         "scipy==1.12.0",
         "stanza==1.4.2",
         "torch==1.13.1",


### PR DESCRIPTION
Update `scikit-learn` to the latest `1.5.0` because Dependabot alerted [CVE-2024-5206](
https://github.com/xcoo/jp-cancer-ehrs-analysis/security/dependabot/2).

I have confirmed that `emr_analysis.ipynb` was executed normally.