### PR TITLE
Update torch to 2.4.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - JUPYTER_CONFIG_DIR=/jupyter/config
       - JUPYTER_DATA_DIR=/jupyter/data
       - JUPYTER_RUNTIME_DIR=/jupyter/runtime
-      - LD_PRELOAD=/usr/local/lib/python3.9/site-packages/torch/lib/libgomp-d22c30c5.so.1
+      - LD_PRELOAD=/usr/local/lib/python3.9/site-packages/torch.libs/libgomp-804f19d4.so.1.0.0
     ports:
       - "8888:8888"
       - "6006:6006"

--- a/emr_analysis.ipynb
+++ b/emr_analysis.ipynb
@@ -190,16 +190,53 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-01-05 16:44:56 INFO: Loading these models for language: ja (Japanese):\n",
+      "2024-07-31 09:25:15 INFO: Checking for updates to resources.json in case models have been updated.  Note: this behavior can be turned off with download_method=None or download_method=DownloadMethod.REUSE_RESOURCES\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5118b4f379d14a62af5efed4c6014814",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading https://raw.githubusercontent.com/stanfordnlp/stanza-resources/main/resources_1.4.1.json:   0%|   …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2caae8bc5e7346c9b8a9bd1153fdaf07",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading https://huggingface.co/stanfordnlp/stanza-ja/resolve/v1.4.1/models/tokenize/gsd.pt:   0%|         …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-07-31 09:25:16 INFO: Loading these models for language: ja (Japanese):\n",
       "=======================\n",
       "| Processor | Package |\n",
       "-----------------------\n",
       "| tokenize  | gsd     |\n",
       "=======================\n",
       "\n",
-      "2024-01-05 16:44:56 INFO: Use device: cpu\n",
-      "2024-01-05 16:44:56 INFO: Loading: tokenize\n",
-      "2024-01-05 16:44:56 INFO: Done loading processors!\n"
+      "2024-07-31 09:25:16 INFO: Use device: cpu\n",
+      "2024-07-31 09:25:16 INFO: Loading: tokenize\n",
+      "/usr/local/lib/python3.9/site-packages/stanza/models/tokenization/trainer.py:88: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.\n",
+      "  checkpoint = torch.load(filename, lambda storage, loc: storage)\n",
+      "2024-07-31 09:25:17 INFO: Done loading processors!\n"
      ]
     },
     {

--- a/emr_analysis/effect/detector.py
+++ b/emr_analysis/effect/detector.py
@@ -58,7 +58,7 @@ class LSTMClassifier0(nn.Module):
 
     @staticmethod
     def load(f, device) -> LSTMClassifier0:
-        obj = torch.load(f, map_location=device)
+        obj = torch.load(f, map_location=device, weights_only=False)
         model = LSTMClassifier0(obj["max_reports"], obj["max_tokens"], obj["embedding_dim"],
                                 obj["hidden_dim"], obj["bidirectional"],
                                 num_layers=obj["num_layers"], dropout=obj["dropout"])
@@ -118,7 +118,7 @@ class LSTMClassifier(nn.Module):
 
     @staticmethod
     def load(f, device) -> LSTMClassifier:
-        obj = torch.load(f, map_location=device)
+        obj = torch.load(f, map_location=device, weights_only=False)
         model = LSTMClassifier(obj["max_reports"], obj["max_tokens"], obj["int2effect_dict"],
                                obj["embedding_dim"], obj["hidden_dim"], obj["label_size"],
                                obj["bidirectional"], num_layers=obj["num_layers"],

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
         "scikit-learn==1.5.0",
         "scipy==1.12.0",
         "stanza==1.4.2",
-        "torch==1.13.1",
+        "torch==2.4.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
I have updated `torch` to `2.4.0` due to two security alerts https://github.com/xcoo/jp-cancer-ehrs-analysis/security/dependabot/3 and https://github.com/xcoo/jp-cancer-ehrs-analysis/security/dependabot/4.

I have confirmed that `emr_analysis.ipynb` could be run normally.